### PR TITLE
fix: add prettier-plugin-svelte and prettierrc to fix rules

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -18,7 +18,6 @@
         "prettier"
     ],
     "rules": {
-        "prettier/prettier": ["error", {"singleQuote": true}],
         "indent": [
             "error",
             "tab"

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+	"singleQuote": true,
+	"semi": false,
+	"useTabs": true
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
+    "prettier-plugin-svelte": "^2.1.0",
     "snowpack": "^3.0.1",
     "svelte-jester": "^1.3.0",
     "svelte-preprocess": "^4.0.8",


### PR DESCRIPTION
Fixes #4 

Added [prettier-plugin-svelte](https://github.com/sveltejs/prettier-plugin-svelte) and moved the Prettier rules from `eslintrc` to `prettierrc`.
