### PR TITLE
Remove code style rules from eslint

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -15,10 +15,5 @@
     "sourceType": "module"
   },
   "plugins": ["@typescript-eslint", "prettier"],
-  "rules": {
-    "indent": ["error", 2],
-    "linebreak-style": ["error", "unix"],
-    "quotes": ["error", "single"],
-    "semi": ["error", "never"]
-  }
+  "rules": {}
 }


### PR DESCRIPTION
We shouldn't need it because we have `eslint-plugin-prettier` to handle these rules