### PR TITLE
Run precommit only on changed files

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  '*.+(js|jsx|ts|tsx)': ['yarn lint'],
-  // '*.+(js|jsx|ts|tsx)': ['eslint', 'yarn test:precommit'],
-  '*.+(js|jsx|json|yml|yaml|css|ts|tsx)': ['prettier --write'],
+  '*.+(js|jsx|ts|tsx)': ['eslint --fix'],
+  '*.+(json|yml|yaml|css)': ['prettier --write'],
 }


### PR DESCRIPTION
run eslint in precommit only on changed files.
using my super scientific measurement 😅 this is the time difference

before:
```
✔ Preparing...
✔ Running tasks...
✖ Prevented an empty git commit!
✔ Reverting to original state because of errors...
✔ Cleaning up...

  ⚠ lint-staged prevented an empty git commit.
  Use the --allow-empty option to continue, or check your task configuration


________________________________________________________
Executed in    2.20 secs   fish           external 
   usr time    3.02 secs  567.00 micros    3.02 secs 
   sys time    0.24 secs  480.00 micros    0.24 secs 
```

after:
```
✔ Preparing...
✔ Running tasks...
✖ Prevented an empty git commit!
✔ Reverting to original state because of errors...
✔ Cleaning up...

  ⚠ lint-staged prevented an empty git commit.
  Use the --allow-empty option to continue, or check your task configuration


________________________________________________________
Executed in    1.31 secs   fish           external 
   usr time  1491.01 millis  482.00 micros  1490.53 millis 
   sys time  144.57 millis  408.00 micros  144.17 millis 
```
fixes #54